### PR TITLE
Fix typo in reference datatype

### DIFF
--- a/language/llama2-70b/README.md
+++ b/language/llama2-70b/README.md
@@ -237,7 +237,7 @@ The ServerSUT was not tested for GPU runs.
 
 
 ## Accuracy Target
-Running the GPU implementation in FP32 precision resulted in the following FP32 accuracy targets (normalized to a 0-100
+Running the GPU implementation in FP16 precision resulted in the following FP16 accuracy targets (normalized to a 0-100
 scale from a 0.0-1.0 scale):
 - Rouge1: 44.4312
 - Rouge2: 22.0352


### PR DESCRIPTION
Change baseline accuracy datatype of Llama2-70B from fp32 to fp16